### PR TITLE
feat: Topic filter using regular expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ ros2 bag merge -o rosbag2_merged/ rosbag2_2021_08_20-12_28_24/ rosbag2_2021_08_2
 
 - ros2 bag filter
 
-Filter by topic names.
+Filter by topic names. You can use [python3 regular expression operations](https://docs.python.org/3.8/library/re.html).
 
 Usage:
 

--- a/ros2bag_extensions/ros2bag_extensions/verb/filter.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/filter.py
@@ -14,6 +14,7 @@
 
 import os
 from typing import List
+import re
 
 from ros2bag.api import check_path_exists
 from ros2bag.verb import VerbExtension
@@ -29,9 +30,17 @@ class FilterVerb(VerbExtension):
 
         # Filter topics
         if include_topics:
-            topic_list = [topic.name for topic in reader.get_all_topics_and_types() if topic.name in include_topics]
+            topic_list = [topic.name for topic in reader.get_all_topics_and_types()]
+            include_topic_list = []
+            for include_topic in include_topics:
+                include_topic_list += [topic_name for topic_name in topic_list if re.match(include_topic, topic_name)]
+            topic_list = list(set(topic_list).intersection(set(include_topic_list)))
         elif exclude_topics:
-            topic_list = [topic.name for topic in reader.get_all_topics_and_types() if topic.name not in exclude_topics]
+            topic_list = [topic.name for topic in reader.get_all_topics_and_types()]
+            exclude_topic_list = []
+            for exclude_topic in exclude_topics:
+                exclude_topic_list += [topic_name for topic_name in topic_list if re.match(exclude_topic, topic_name)]
+            topic_list = list(set(topic_list).difference(set(exclude_topic_list)))
         else:
             topic_list = [topic.name for topic in reader.get_all_topics_and_types()]
 


### PR DESCRIPTION
## Description
support to filter topics with regular expressions.

## How to use

I used the sample-bag in the tutorial of Autoware. You can filter a single topic or multiple topics with regex.

```
❯ ros2 bag info sample-rosbag

Files:             sample.db3
Bag size:          262.7 MiB
Storage id:        sqlite3
Duration:          29.874s
Start:             Feb 26 2021 14:02:26.338 (1614315746.338)
End:               Feb 26 2021 14:02:56.212 (1614315776.212)
Messages:          8262
Topic information: Topic: /clock | Type: rosgraph_msgs/msg/Clock | Count: 2941 | Serialization Format: cdr
                   Topic: /sensing/gnss/ublox/fix_velocity | Type: geometry_msgs/msg/TwistWithCovarianceStamped | Count: 30 | Serialization Format: cdr
                   Topic: /sensing/gnss/ublox/nav_sat_fix | Type: sensor_msgs/msg/NavSatFix | Count: 30 | Serialization Format: cdr
                   Topic: /sensing/gnss/ublox/navpvt | Type: ublox_msgs/msg/NavPVT | Count: 30 | Serialization Format: cdr
                   Topic: /sensing/imu/tamagawa/imu_raw | Type: sensor_msgs/msg/Imu | Count: 853 | Serialization Format: cdr
                   Topic: /sensing/lidar/left/velodyne_packets | Type: velodyne_msgs/msg/VelodyneScan | Count: 299 | Serialization Format: cdr
                   Topic: /sensing/lidar/right/velodyne_packets | Type: velodyne_msgs/msg/VelodyneScan | Count: 299 | Serialization Format: cdr
                   Topic: /sensing/lidar/top/velodyne_packets | Type: velodyne_msgs/msg/VelodyneScan | Count: 288 | Serialization Format: cdr
                   Topic: /vehicle/status/control_mode | Type: autoware_auto_vehicle_msgs/msg/ControlModeReport | Count: 873 | Serialization Format: cdr
                   Topic: /vehicle/status/gear_status | Type: autoware_auto_vehicle_msgs/msg/GearReport | Count: 873 | Serialization Format: cdr
                   Topic: /vehicle/status/steering_status | Type: autoware_auto_vehicle_msgs/SteeringReport | Count: 873 | Serialization Format: cdr
                   Topic: /vehicle/status/velocity_status | Type: autoware_auto_vehicle_msgs/msg/VelocityReport | Count: 873 | Serialization Format: cdr

```

Check the results.

```
~/Data/autoware_sample
❯ ros2 bag filter sample-rosbag -o sample-rosbag-in -i "/sensing/*"
[INFO 1654582452.850600851] [rosbag2_storage]: Opened database 'sample-rosbag/sample.db3' for READ_ONLY.
[INFO 1654582452.851529237] [rosbag2_storage]: Opened database 'sample-rosbag-in/sample-rosbag-in_0.db3' for READ_WRITE.
[INFO 1654582453.240320684] [rosbag2_cpp]: Beginning reindexing bag in directory: sample-rosbag-in
[INFO 1654582453.240493624] [rosbag2_storage]: Opened database 'sample-rosbag-in/sample-rosbag-in_0.db3' for READ_ONLY.
[INFO 1654582453.242540689] [rosbag2_cpp]: Reindexing complete.

~/Data/autoware_sample
❯ ros2 bag info sample-rosbag-in

Files:             sample-rosbag-in_0.db3
Bag size:          262.2 MiB
Storage id:        sqlite3
Duration:          29.872s
Start:             Feb 26 2021 14:02:26.340 (1614315746.340)
End:               Feb 26 2021 14:02:56.212 (1614315776.212)
Messages:          1829
Topic information: Topic: /sensing/gnss/ublox/fix_velocity | Type: geometry_msgs/msg/TwistWithCovarianceStamped | Count: 30 | Serialization Format: cdr
                   Topic: /sensing/gnss/ublox/nav_sat_fix | Type: sensor_msgs/msg/NavSatFix | Count: 30 | Serialization Format: cdr
                   Topic: /sensing/gnss/ublox/navpvt | Type: ublox_msgs/msg/NavPVT | Count: 30 | Serialization Format: cdr
                   Topic: /sensing/imu/tamagawa/imu_raw | Type: sensor_msgs/msg/Imu | Count: 853 | Serialization Format: cdr
                   Topic: /sensing/lidar/left/velodyne_packets | Type: velodyne_msgs/msg/VelodyneScan | Count: 299 | Serialization Format: cdr
                   Topic: /sensing/lidar/right/velodyne_packets | Type: velodyne_msgs/msg/VelodyneScan | Count: 299 | Serialization Format: cdr
                   Topic: /sensing/lidar/top/velodyne_packets | Type: velodyne_msgs/msg/VelodyneScan | Count: 288 | Serialization Format: cdr


~/Data/autoware_sample
❯ ros2 bag filter sample-rosbag -o sample-rosbag-ex -x "/sensing/*"
[INFO 1654582471.907419499] [rosbag2_storage]: Opened database 'sample-rosbag/sample.db3' for READ_ONLY.
[INFO 1654582471.908375259] [rosbag2_storage]: Opened database 'sample-rosbag-ex/sample-rosbag-ex_0.db3' for READ_WRITE.
[INFO 1654582471.993263302] [rosbag2_cpp]: Beginning reindexing bag in directory: sample-rosbag-ex
[INFO 1654582471.993453158] [rosbag2_storage]: Opened database 'sample-rosbag-ex/sample-rosbag-ex_0.db3' for READ_ONLY.
[INFO 1654582471.998394084] [rosbag2_cpp]: Reindexing complete.

~/Data/autoware_sample
❯ ros2 bag info sample-rosbag-ex

Files:             sample-rosbag-ex_0.db3
Bag size:          357.6 KiB
Storage id:        sqlite3
Duration:          29.873s
Start:             Feb 26 2021 14:02:26.338 (1614315746.338)
End:               Feb 26 2021 14:02:56.211 (1614315776.211)
Messages:          6433
Topic information: Topic: /clock | Type: rosgraph_msgs/msg/Clock | Count: 2941 | Serialization Format: cdr
                   Topic: /vehicle/status/control_mode | Type: autoware_auto_vehicle_msgs/msg/ControlModeReport | Count: 873 | Serialization Format: cdr
                   Topic: /vehicle/status/gear_status | Type: autoware_auto_vehicle_msgs/msg/GearReport | Count: 873 | Serialization Format: cdr
                   Topic: /vehicle/status/steering_status | Type: autoware_auto_vehicle_msgs/SteeringReport | Count: 873 | Serialization Format: cdr
                   Topic: /vehicle/status/velocity_status | Type: autoware_auto_vehicle_msgs/msg/VelocityReport | Count: 873 | Serialization Format: cdr

```

