### PR TITLE
docs: update regular expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,16 +50,16 @@ If you want to include the specified topic, use `-i` or `--include`.
 
 ```sh
 ros2 bag filter -o rosbag2_filtered/ rosbag2_merged/ -i "/system/emergency/turn_signal_cmd" "/autoware/driving_capability"
-# use Regular expression, wildcard
-ros2 bag filter -o rosbag2_filtered/ rosbag2_merged/ -i "/sensing/*" "/vehicle/*"
+# use regular expression
+ros2 bag filter -o rosbag2_filtered/ rosbag2_merged/ -i "/sensing/.*" "/vehicle/.*"
 ```
 
 If you want to exclude the specified topic, use `-x` or `--exclude`.
 
 ```sh
 ros2 bag filter -o rosbag2_filtered/ rosbag2_merged/ -x "/system/emergency/turn_signal_cmd" "/autoware/driving_capability"
-# use Regular expression, wildcard
-ros2 bag filter -o rosbag2_filtered/ rosbag2_merged/ -x "/sensing/*" "/vehicle/*"
+# use regular expression
+ros2 bag filter -o rosbag2_filtered/ rosbag2_merged/ -x "/sensing/.*" "/vehicle/.*"
 ```
 
 - ros2 bag slice


### PR DESCRIPTION
If you use re fullmatch method, the expression "/sensing/\*" does not match "/sensing/xxxx" because "/\*" means zero or more repetitions of "/".

So if you want to match "/sensing/xxx", you need to use the expression "/sensing/. *".
I fixed the regular expression in the README.md.