### PR TITLE
feat(slice): add duration option

### DIFF
--- a/ros2bag_extensions/package.xml
+++ b/ros2bag_extensions/package.xml
@@ -11,6 +11,7 @@
 
   <depend>ros2bag</depend>
   <depend>rosbag2_py</depend>
+  <depend>rosbag2_py_wrapper</depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/ros2bag_extensions/ros2bag_extensions/verb/slice.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/slice.py
@@ -18,13 +18,15 @@ import os
 from ros2bag.api import check_path_exists
 from ros2bag.verb import VerbExtension
 from rosbag2_py import *
+from rosbag2_py_wrapper import SequentialWriterWrapper
 
 from . import create_reader, get_default_converter_options, get_default_storage_options
 
 
 class SliceVerb(VerbExtension):
+
     ''' Save the specified range of data as a bag file by specifying the start time and end time. '''
-    def _bag2slice(self, input_bag_dir: str, output_bag_dir: str, start_time: datetime.datetime, end_time: datetime.datetime) -> None:
+    def _bag2slice_with_start_end_time(self, input_bag_dir: str, output_bag_dir: str, start_time: datetime.datetime, end_time: datetime.datetime) -> None:
         # Check timestamp
         metadata = Info().read_metadata(input_bag_dir, "sqlite3")
 
@@ -54,6 +56,33 @@ class SliceVerb(VerbExtension):
             if start_time <= datetime_stamp <= end_time:
                 writer.write(topic_name, msg, stamp)
 
+    ''' Split and save bag files by specifying the duration. '''
+    def _bag2slice_with_duration(self, input_bag_dir: str, output_bag_dir: str, duration: float) -> None:
+        # Open writer
+        storage_options = get_default_storage_options(output_bag_dir)
+        converter_options = get_default_converter_options()
+        writer = SequentialWriterWrapper()
+        writer.open(storage_options, converter_options)
+
+        # Create topics
+        reader = create_reader(input_bag_dir)
+        for topic_type in reader.get_all_topics_and_types():
+            writer.create_topic(topic_type)
+
+        # Write
+        split_timestamp = None
+        while reader.has_next():
+            topic_name, msg, stamp = reader.read_next()
+            if split_timestamp is None:
+                split_timestamp = stamp
+            writer.write(topic_name, msg, stamp)
+            time_diff = (stamp - split_timestamp) / 1e9
+            if time_diff > duration:
+                writer.split_bagfile()
+                split_timestamp = stamp
+
+
+
 
     def add_arguments(self, parser, cli_name):
         parser.add_argument(
@@ -61,16 +90,23 @@ class SliceVerb(VerbExtension):
         parser.add_argument(
             "-o", "--output", required=True, help="Output directory")
         parser.add_argument(
-            "-s", "--start-time", default=0.0, type=float, help="Start time in nanoseconds")
+            "-s", "--start-time", type=float, help="Start time in nanoseconds")
         parser.add_argument(
-            "-e", "--end-time", default=4102412400, type=float, help="End time in nanoseconds") # 2100/01/01 00:00:00
-
+            "-e", "--end-time", type=float, help="End time in nanoseconds") # 2100/01/01 00:00:00
+        parser.add_argument(
+            "-d", "--duration", type=float, help="duration second for slice")
 
     def main(self, *, args):
         if os.path.isdir(args.output):
             raise FileExistsError("Output folder '{}' already exists.".format(args.output))
 
-        dt_start_time = datetime.datetime.fromtimestamp(args.start_time)
-        dt_end_time = datetime.datetime.fromtimestamp(args.end_time)
+        # start_time and end_time exists
+        if args.start_time is not None and args.end_time is not None:
+            dt_start_time = datetime.datetime.fromtimestamp(args.start_time)
+            dt_end_time = datetime.datetime.fromtimestamp(args.end_time)
 
-        self._bag2slice(args.bag_directory, args.output, dt_start_time, dt_end_time)
+            self._bag2slice_with_start_end_time(args.bag_directory, args.output, dt_start_time, dt_end_time)
+        elif args.duration is not None:
+            self._bag2slice_with_duration(args.bag_directory, args.output, args.duration)
+        else:
+            print("please specify start and end time or duration")

--- a/ros2bag_extensions/ros2bag_extensions/verb/slice.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/slice.py
@@ -24,7 +24,6 @@ from . import create_reader, get_default_converter_options, get_default_storage_
 
 
 class SliceVerb(VerbExtension):
-
     ''' Save the specified range of data as a bag file by specifying the start time and end time. '''
     def _bag2slice_with_start_end_time(self, input_bag_dir: str, output_bag_dir: str, start_time: datetime.datetime, end_time: datetime.datetime) -> None:
         # Check timestamp

--- a/rosbag2_py_wrapper/CMakeLists.txt
+++ b/rosbag2_py_wrapper/CMakeLists.txt
@@ -12,50 +12,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake_auto REQUIRED)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+
 ament_auto_find_build_dependencies()
-
-# Find python before pybind11
-find_package(python_cmake_module REQUIRED)
-find_package(PythonExtra REQUIRED)
-if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-  # Set the python debug interpreter.
-  # pybind11 will setup the build for debug now.
-  set(PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
-endif()
-
-find_package(pybind11 REQUIRED)
-
-if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-  # pybind11 logic for setting up a debug build when both a debug and release
-  # python interpreter are present in the system seems to be pretty much broken.
-  # This works around the issue.
-  set(PYTHON_LIBRARIES "${PYTHON_DEBUG_LIBRARIES}")
-endif()
-
-function(clean_windows_flags target)
-  # Hack to avoid pybind11 issue.
-  #
-  # TODO(ivanpauno):
-  # This can be deleted when we update `pybind11_vendor` to a version including
-  # https://github.com/pybind/pybind11/pull/2590.
-  #
-  # They are enabling /LTCG on Windows to reduce binary size,
-  # but that doesn't play well with MSVC incremental linking (default for Debug/RelWithDebInfo).
-  #
-  # See:
-  # - https://docs.microsoft.com/en-us/cpp/build/reference/incremental-link-incrementally?view=vs-2019
-  # - https://docs.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=vs-2019
-
-  if(MSVC AND "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
-    get_target_property(target_link_libraries ${target} LINK_LIBRARIES)
-    list(REMOVE_ITEM target_link_libraries "$<$<NOT:$<CONFIG:Debug>>:-LTCG>")
-    set_target_properties(${target} PROPERTIES LINK_LIBRARIES "${target_link_libraries}")
-
-    get_target_property(target_compile_options ${target} COMPILE_OPTIONS)
-    list(REMOVE_ITEM target_compile_options "$<$<NOT:$<CONFIG:Debug>>:/GL>")
-    set_target_properties(${target} PROPERTIES COMPILE_OPTIONS "${target_compile_options}")
-  endif()
-endfunction()
 
 ament_python_install_package(${PROJECT_NAME})
 
@@ -65,7 +24,6 @@ pybind11_add_module(_writer SHARED
 ament_target_dependencies(_writer PUBLIC
   "rosbag2_cpp"
 )
-clean_windows_flags(_writer)
 
 # Install cython modules as sub-modules of the project
 install(

--- a/rosbag2_py_wrapper/CMakeLists.txt
+++ b/rosbag2_py_wrapper/CMakeLists.txt
@@ -1,0 +1,84 @@
+cmake_minimum_required(VERSION 3.5)
+project(rosbag2_py_wrapper)
+
+### Compile options
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+# Find python before pybind11
+find_package(python_cmake_module REQUIRED)
+find_package(PythonExtra REQUIRED)
+if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # Set the python debug interpreter.
+  # pybind11 will setup the build for debug now.
+  set(PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE_DEBUG}")
+endif()
+
+find_package(pybind11 REQUIRED)
+
+if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # pybind11 logic for setting up a debug build when both a debug and release
+  # python interpreter are present in the system seems to be pretty much broken.
+  # This works around the issue.
+  set(PYTHON_LIBRARIES "${PYTHON_DEBUG_LIBRARIES}")
+endif()
+
+function(clean_windows_flags target)
+  # Hack to avoid pybind11 issue.
+  #
+  # TODO(ivanpauno):
+  # This can be deleted when we update `pybind11_vendor` to a version including
+  # https://github.com/pybind/pybind11/pull/2590.
+  #
+  # They are enabling /LTCG on Windows to reduce binary size,
+  # but that doesn't play well with MSVC incremental linking (default for Debug/RelWithDebInfo).
+  #
+  # See:
+  # - https://docs.microsoft.com/en-us/cpp/build/reference/incremental-link-incrementally?view=vs-2019
+  # - https://docs.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=vs-2019
+
+  if(MSVC AND "${CMAKE_BUILD_TYPE}" STREQUAL "RelWithDebInfo")
+    get_target_property(target_link_libraries ${target} LINK_LIBRARIES)
+    list(REMOVE_ITEM target_link_libraries "$<$<NOT:$<CONFIG:Debug>>:-LTCG>")
+    set_target_properties(${target} PROPERTIES LINK_LIBRARIES "${target_link_libraries}")
+
+    get_target_property(target_compile_options ${target} COMPILE_OPTIONS)
+    list(REMOVE_ITEM target_compile_options "$<$<NOT:$<CONFIG:Debug>>:/GL>")
+    set_target_properties(${target} PROPERTIES COMPILE_OPTIONS "${target_compile_options}")
+  endif()
+endfunction()
+
+ament_python_install_package(${PROJECT_NAME})
+
+pybind11_add_module(_writer SHARED
+  src/rosbag2_py_wrapper/_writer.cpp
+)
+ament_target_dependencies(_writer PUBLIC
+  "rosbag2_cpp"
+)
+clean_windows_flags(_writer)
+
+# Install cython modules as sub-modules of the project
+install(
+  TARGETS
+    _writer
+  DESTINATION "${PYTHON_INSTALL_DIR}/${PROJECT_NAME}"
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+  find_package(ament_cmake_pytest REQUIRED)
+
+endif()
+
+ament_package()

--- a/rosbag2_py_wrapper/LICENSE
+++ b/rosbag2_py_wrapper/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/rosbag2_py_wrapper/NOTICE
+++ b/rosbag2_py_wrapper/NOTICE
@@ -1,0 +1,6 @@
+rosbag2
+
+Copyright Holders:
+Copyright (c) 2018, Open Source Robotics Foundation, Inc.
+Copyright (c) 2018, Bosch Software Innovations GmbH
+Copyright 2020 Open Source Robotics Foundation, Inc.

--- a/rosbag2_py_wrapper/package.xml
+++ b/rosbag2_py_wrapper/package.xml
@@ -11,6 +11,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>pybind11_vendor</depend>
+  <depend>pybind11</depend>
   <depend>rosbag2_cpp</depend>
 
   <exec_depend>rpyutils</exec_depend>

--- a/rosbag2_py_wrapper/package.xml
+++ b/rosbag2_py_wrapper/package.xml
@@ -12,18 +12,12 @@
 
   <depend>pybind11_vendor</depend>
   <depend>pybind11</depend>
+  <depend>python_cmake_module</depend>
+  <depend>PythonExtra</depend>
   <depend>rosbag2_cpp</depend>
+  <depend>rosbag2_storage</depend>
 
   <exec_depend>rpyutils</exec_depend>
-
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
-  <test_depend>python3-pytest</test_depend>
-  <test_depend>rcl_interfaces</test_depend>
-  <test_depend>rclpy</test_depend>
-  <test_depend>rosbag2_storage_default_plugins</test_depend>
-  <test_depend>rosidl_runtime_py</test_depend>
-  <test_depend>std_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosbag2_py_wrapper/package.xml
+++ b/rosbag2_py_wrapper/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>rosbag2_py_wrapper</name>
+  <version>0.9.2</version>
+  <description>Wrapper for Python API for rosbag2</description>
+  <maintainer email="hiroki.ota@tier4.jp">Hiroki Ota</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>pybind11_vendor</depend>
+  <depend>rosbag2_cpp</depend>
+
+  <exec_depend>rpyutils</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>python3-pytest</test_depend>
+  <test_depend>rcl_interfaces</test_depend>
+  <test_depend>rclpy</test_depend>
+  <test_depend>rosbag2_storage_default_plugins</test_depend>
+  <test_depend>rosidl_runtime_py</test_depend>
+  <test_depend>std_msgs</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rosbag2_py_wrapper/rosbag2_py_wrapper/__init__.py
+++ b/rosbag2_py_wrapper/rosbag2_py_wrapper/__init__.py
@@ -1,0 +1,28 @@
+# Copyright 2023 TierIV
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from rpyutils import add_dll_directories_from_env
+
+# Since Python 3.8, on Windows we should ensure DLL directories are explicitly added
+# to the search path.
+# See https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew
+with add_dll_directories_from_env('PATH'):
+    from rosbag2_py_wrapper._writer import (
+        SequentialWriterWrapper,
+    )
+
+
+__all__ = [
+    'SequentialWriterWrapper',
+]

--- a/rosbag2_py_wrapper/src/rosbag2_py_wrapper/_writer.cpp
+++ b/rosbag2_py_wrapper/src/rosbag2_py_wrapper/_writer.cpp
@@ -17,12 +17,8 @@
 #include <string>
 #include <unordered_set>
 
-#include "rosbag2_cpp/converter_options.hpp"
 #include "rosbag2_cpp/writers/sequential_writer.hpp"
 #include "rosbag2_storage/ros_helper.hpp"
-#include "rosbag2_storage/storage_filter.hpp"
-#include "rosbag2_storage/storage_options.hpp"
-#include "rosbag2_storage/topic_metadata.hpp"
 
 #include "./pybind11.hpp"
 
@@ -52,14 +48,6 @@ public:
     rosbag2_cpp::writers::SequentialWriter::write(bag_message);
   }
 };
-
-std::unordered_set<std::string> get_registered_writers()
-{
-  rosbag2_storage::StorageFactory storage_factory;
-  const auto read_write = storage_factory.get_declared_read_write_plugins();
-  return std::unordered_set<std::string>(read_write.begin(), read_write.end());
-}
-
 }  // namespace rosbag2_py_wrapper
 
 PYBIND11_MODULE(_writer, m) {
@@ -73,9 +61,4 @@ PYBIND11_MODULE(_writer, m) {
   .def("remove_topic", &rosbag2_py_wrapper::SequentialWriterWrapper::remove_topic)
   .def("create_topic", &rosbag2_py_wrapper::SequentialWriterWrapper::create_topic)
   .def("split_bagfile", &rosbag2_py_wrapper::SequentialWriterWrapper::split_bagfile_wrapper);
-
-  m.def(
-    "get_registered_writers",
-    &rosbag2_py_wrapper::get_registered_writers,
-    "Returns list of discovered plugins that support rosbag2 recording");
 }

--- a/rosbag2_py_wrapper/src/rosbag2_py_wrapper/_writer.cpp
+++ b/rosbag2_py_wrapper/src/rosbag2_py_wrapper/_writer.cpp
@@ -1,0 +1,81 @@
+// Copyright 2023 TierIV
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <unordered_set>
+
+#include "rosbag2_cpp/converter_options.hpp"
+#include "rosbag2_cpp/writers/sequential_writer.hpp"
+#include "rosbag2_storage/ros_helper.hpp"
+#include "rosbag2_storage/storage_filter.hpp"
+#include "rosbag2_storage/storage_options.hpp"
+#include "rosbag2_storage/topic_metadata.hpp"
+
+#include "./pybind11.hpp"
+
+namespace rosbag2_py_wrapper
+{
+
+class SequentialWriterWrapper : public rosbag2_cpp::writers::SequentialWriter
+{
+public:
+  void split_bagfile_wrapper() {
+    this->split_bagfile();
+  }
+
+  /// Write a serialized message to a bag file
+  void write(
+    const std::string & topic_name, const std::string & message,
+    const rcutils_time_point_value_t & time_stamp)
+  {
+    auto bag_message =
+      std::make_shared<rosbag2_storage::SerializedBagMessage>();
+
+    bag_message->topic_name = topic_name;
+    bag_message->serialized_data =
+      rosbag2_storage::make_serialized_message(message.c_str(), message.length());
+    bag_message->time_stamp = time_stamp;
+
+    rosbag2_cpp::writers::SequentialWriter::write(bag_message);
+  }
+};
+
+std::unordered_set<std::string> get_registered_writers()
+{
+  rosbag2_storage::StorageFactory storage_factory;
+  const auto read_write = storage_factory.get_declared_read_write_plugins();
+  return std::unordered_set<std::string>(read_write.begin(), read_write.end());
+}
+
+}  // namespace rosbag2_py_wrapper
+
+PYBIND11_MODULE(_writer, m) {
+  m.doc() = "Python wrapper of the SequentialWriter API";
+
+  pybind11::class_<rosbag2_py_wrapper::SequentialWriterWrapper>(
+    m, "SequentialWriterWrapper")
+  .def(pybind11::init())
+  .def("open", &rosbag2_py_wrapper::SequentialWriterWrapper::open)
+  .def("write", &rosbag2_py_wrapper::SequentialWriterWrapper::write)
+  .def("remove_topic", &rosbag2_py_wrapper::SequentialWriterWrapper::remove_topic)
+  .def("create_topic", &rosbag2_py_wrapper::SequentialWriterWrapper::create_topic)
+  .def("split_bagfile", &rosbag2_py_wrapper::SequentialWriterWrapper::split_bagfile_wrapper);
+
+  m.def(
+    "get_registered_writers",
+    &rosbag2_py_wrapper::get_registered_writers,
+    "Returns list of discovered plugins that support rosbag2 recording");
+}

--- a/rosbag2_py_wrapper/src/rosbag2_py_wrapper/pybind11.hpp
+++ b/rosbag2_py_wrapper/src/rosbag2_py_wrapper/pybind11.hpp
@@ -1,0 +1,31 @@
+// Copyright 2023 TierIV
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSBAG2_PY__PYBIND11_HPP_
+#define ROSBAG2_PY__PYBIND11_HPP_
+
+// Ignore -Wunused-value for clang.
+// Based on https://github.com/pybind/pybind11/issues/2225
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-value"
+#endif
+#include <pybind11/pybind11.h>
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
+#include <pybind11/stl.h>
+#include <pybind11/chrono.h>
+
+#endif  // ROSBAG2_PY__PYBIND11_HPP_


### PR DESCRIPTION
## Description
- add `--duration` option for `slice` verb, which make rosbag split into multiple files
- add `rosbag2_py_wrapper` package to realize its function

## Test performed
### start and end time option
```
ros2 bag slice rosbag.db3 -o output --start-time 0 --end-time 123455678
```
After that

### duration option
```
ros2 bag slice rosbag.db3 -o output --duration 10
```
After that, I confirmed multiple files which has 10secs data

## Remarks
I made rosbag_py_wrapper based on https://github.com/ros2/rosbag2/tree/rolling/rosbag2_py.
Please check License too.