### PR TITLE
fix(slice): use only start or end time

### DIFF
--- a/ros2bag_extensions/ros2bag_extensions/verb/slice.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/slice.py
@@ -80,18 +80,15 @@ class SliceVerb(VerbExtension):
                 writer.split_bagfile()
                 split_timestamp = stamp
 
-
-
-
     def add_arguments(self, parser, cli_name):
         parser.add_argument(
             "bag_directory", type=check_path_exists, help="Bag to filter")
         parser.add_argument(
             "-o", "--output", required=True, help="Output directory")
         parser.add_argument(
-            "-s", "--start-time", type=float, help="Start time in nanoseconds")
+            "-s", "--start-time", default=0.0, type=float, help="Start time in nanoseconds")
         parser.add_argument(
-            "-e", "--end-time", type=float, help="End time in nanoseconds") # 2100/01/01 00:00:00
+            "-e", "--end-time", default=4102412400, type=float, help="End time in nanoseconds")  # 2100/01/01 00:00:00
         parser.add_argument(
             "-d", "--duration", type=float, help="duration second for slice")
 
@@ -99,13 +96,10 @@ class SliceVerb(VerbExtension):
         if os.path.isdir(args.output):
             raise FileExistsError("Output folder '{}' already exists.".format(args.output))
 
-        # start_time and end_time exists
-        if args.start_time is not None and args.end_time is not None:
+        # duration mode
+        if args.duration is not None:
+            self._bag2slice_with_duration(args.bag_directory, args.output, args.duration)
+        else:  # start and end mode
             dt_start_time = datetime.datetime.fromtimestamp(args.start_time)
             dt_end_time = datetime.datetime.fromtimestamp(args.end_time)
-
             self._bag2slice_with_start_end_time(args.bag_directory, args.output, dt_start_time, dt_end_time)
-        elif args.duration is not None:
-            self._bag2slice_with_duration(args.bag_directory, args.output, args.duration)
-        else:
-            print("please specify start and end time or duration")


### PR DESCRIPTION
This PR fixes #20 
- fix for using only start or end time
- decide duration mode when `--duration` is given
- you can use start or end time if you don't specify `--duration`

### Tests Performed

```sh
$ ros2 bag info .

Files:             output_0.db3
Bag size:          676.7 MiB
Storage id:        sqlite3
Duration:          599.998s
Start:             Dec 20 2022 13:50:17.830 (1671511817.830)
End:               Dec 20 2022 14:00:17.829 (1671512417.829)
Messages:          431269
...
```

#### --start-time

```sh
$ ros2 bag slice output_0.db3 -o sliced_from -s 1671511917
[INFO 1678840769.682450960] [rosbag2_storage] open(): Opened database 'output_0.db3' for READ_ONLY.
No valid end time set. End time automatically set the bag end time.
[INFO 1678840770.189033311] [rosbag2_storage] open(): Opened database 'sliced_from/sliced_from_0.db3' for READ_WRITE.
[INFO 1678840770.190260870] [rosbag2_storage] open(): Opened database 'output_0.db3' for READ_ONLY.


$ ros2 bag info sliced_from/

Files:             sliced_from_0.db3
Bag size:          564.9 MiB
Storage id:        sqlite3
Duration:          500.825s
Start:             Dec 20 2022 13:51:57.2 (1671511917.2)
End:               Dec 20 2022 14:00:17.828 (1671512417.828)
Messages:          360064
...
```

#### --end-time
```sh
$ ros2 bag slice output_0.db3 -o sliced_till -e 1671512217
[INFO 1678840830.301002892] [rosbag2_storage] open(): Opened database 'output_0.db3' for READ_ONLY.
No valid start time set. Start time automatically set the bag start time.
[INFO 1678840830.821919000] [rosbag2_storage] open(): Opened database 'sliced_till/sliced_till_0.db3' for READ_WRITE.
[INFO 1678840830.822856352] [rosbag2_storage] open(): Opened database 'output_0.db3' for READ_ONLY.


$ ros2 bag info sliced_till

Files:             sliced_till_0.db3
Bag size:          450.1 MiB
Storage id:        sqlite3
Duration:          399.167s
Start:             Dec 20 2022 13:50:17.830 (1671511817.830)
End:               Dec 20 2022 13:56:56.997 (1671512216.997)
Messages:          286898
...
```

#### ---duration
```sh
$ ros2 bag slice output_0.db3 -o sliced_duration --duration 60
[INFO 1678841088.179731942] [rosbag2_storage] open(): Opened database 'sliced_duration/sliced_duration_0.db3' for READ_WRITE.
[INFO 1678841088.180660619] [rosbag2_storage] open(): Opened database 'output_0.db3' for READ_ONLY.
[INFO 1678841089.698211501] [rosbag2_storage] open(): Opened database 'sliced_duration/sliced_duration_1.db3' for READ_WRITE.
[INFO 1678841090.697197514] [rosbag2_storage] open(): Opened database 'sliced_duration/sliced_duration_2.db3' for READ_WRITE.
...


$ ros2 bag info sliced_duration/

Files:             sliced_duration_0.db3
                   sliced_duration_1.db3
                   sliced_duration_2.db3
                   sliced_duration_3.db3
                   sliced_duration_4.db3
                   sliced_duration_5.db3
                   sliced_duration_6.db3
                   sliced_duration_7.db3
                   sliced_duration_8.db3
                   sliced_duration_9.db3
Bag size:          676.4 MiB
Storage id:        sqlite3
Duration:          599.998s
Start:             Dec 20 2022 13:50:17.830 (1671511817.830)
End:               Dec 20 2022 14:00:17.829 (1671512417.829)
Messages:          431269
...
```
