### PR TITLE
feat: support latched topics

### DIFF
--- a/ros2bag_extensions/ros2bag_extensions/verb/slice.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/slice.py
@@ -56,8 +56,10 @@ class SliceVerb(VerbExtension):
             datetime_stamp = datetime.datetime.fromtimestamp(stamp / 1e9)
             if start_time <= datetime_stamp <= end_time:
                 writer.write(topic_name, msg, stamp)
-                for kept_topic in kept_topics:
+                while kept_topics:
+                    kept_topic = kept_topics.pop(0)
                     writer.write(kept_topic[0], kept_topic[1], stamp)
+
             elif topic_name in latched_topic:
                 kept_topics.append((topic_name, msg))
 

--- a/ros2bag_extensions/ros2bag_extensions/verb/slice.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/slice.py
@@ -25,7 +25,7 @@ from . import create_reader, get_default_converter_options, get_default_storage_
 
 class SliceVerb(VerbExtension):
     ''' Save the specified range of data as a bag file by specifying the start time and end time. '''
-    def _bag2slice_with_start_end_time(self, input_bag_dir: str, output_bag_dir: str, start_time: datetime.datetime, end_time: datetime.datetime) -> None:
+    def _bag2slice_with_start_end_time(self, input_bag_dir: str, output_bag_dir: str, start_time: datetime.datetime, end_time: datetime.datetime, latched_topic: list[str]) -> None:
         # Check timestamp
         metadata = Info().read_metadata(input_bag_dir, "sqlite3")
 
@@ -48,12 +48,18 @@ class SliceVerb(VerbExtension):
         for topic_type in reader.get_all_topics_and_types():
             writer.create_topic(topic_type)
 
+        kept_topics = []
+
         # Write
         while reader.has_next():
             topic_name, msg, stamp = reader.read_next()
             datetime_stamp = datetime.datetime.fromtimestamp(stamp / 1e9)
             if start_time <= datetime_stamp <= end_time:
                 writer.write(topic_name, msg, stamp)
+                for kept_topic in kept_topics:
+                    writer.write(kept_topic[0], kept_topic[1], stamp)
+            elif topic_name in latched_topic:
+                kept_topics.append((topic_name, msg))
 
     ''' Split and save bag files by specifying the duration. '''
     def _bag2slice_with_duration(self, input_bag_dir: str, output_bag_dir: str, duration: float) -> None:
@@ -91,6 +97,9 @@ class SliceVerb(VerbExtension):
             "-e", "--end-time", default=4102412400, type=float, help="End time in nanoseconds")  # 2100/01/01 00:00:00
         parser.add_argument(
             "-d", "--duration", type=float, help="duration second for slice")
+        parser.add_argument(
+            "-l", "--latched-topics", nargs="*", type=str, help="list of latched topics", default=[]
+        )
 
     def main(self, *, args):
         if os.path.isdir(args.output):

--- a/ros2bag_extensions/ros2bag_extensions/verb/slice.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/slice.py
@@ -111,4 +111,4 @@ class SliceVerb(VerbExtension):
         else:  # start and end mode
             dt_start_time = datetime.datetime.fromtimestamp(args.start_time)
             dt_end_time = datetime.datetime.fromtimestamp(args.end_time)
-            self._bag2slice_with_start_end_time(args.bag_directory, args.output, dt_start_time, dt_end_time)
+            self._bag2slice_with_start_end_time(args.bag_directory, args.output, dt_start_time, dt_end_time, args.latched_topics)


### PR DESCRIPTION
/tf_staticや、/planning/mission_planning/routeなどのlatched topicは、bag recordで記録するときには1回分しか記録されない。
latched topicがsliceのstart timeより前に出力される場合、latched topicがなくなってしまう。
sliceの引数として、--latched-topics オプションを追加し、指定されたtopicは、sliceのstart時間にbagに書き戻すことでlatched-topicが消えないようにした。

Latched topics such as /tf_static and /planning/mission_planning/route are only recorded once when recorded in bag record.
If the latched topic is output before the start time of the slice, the latched topic will be lost.
The --latched-topics option was added as an argument to slice, and the specified topic is written back to the bag at the slice start time, so that the latched-topic is not lost.

https://github.com/tier4/ros2bag_extensions/assets/16977736/85f8c173-6ca0-4be6-a3e1-18635bc3c2fd

bagの開始時刻1709009512.447の2秒後の1709009514.556175635に/planning/mission_planning/routeが入っている。

↓のコマンドを打ったら/planning/mission_planning/routeは消える。
ros2 bag slice input_bag/ -o slice_bag -s 1709009630 -e 1709009645

PRの機能でlateched_topicsを指定すると残る
ros2 bag slice input_bag/ -o slice_bag -s 1709009630 -e 1709009645 -l /planning/mission_planning/route


The /planning/mission_planning/route is in 1709009514.556175635, 2 seconds after the start time of bag 1709009512.447.

If you type the command below, /planning/mission_planning/route will disappear.
ros2 bag slice input_bag/ -o slice_bag -s 1709009630 -e 1709009645

If lateched_topics is specified in the PR function, it remains
ros2 bag slice input_bag/ -o slice_bag -s 1709009630 -e 1709009645 -l /planning/mission_planning/route



