### PR TITLE
Support for MCAP Storage Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,15 @@ Extension commands for rosbag in ROS 2
 
 Supported ROS distributions:
 
-- galactic
 - humble
+
+### Optional
+
+If you want to use `mcap` format bags, you need to install the mcap package in advance.
+
+```shell
+sudo apt install ros-humble-rosbag2-storage-mcap
+```
 
 ### Build
 
@@ -42,7 +49,11 @@ Merge multiple bag files.
 Usage:
 
 ```sh
+# sqlite3 format bag
 ros2 bag merge -o rosbag2_merged/ rosbag2_2021_08_20-12_28_24/ rosbag2_2021_08_20-12_30_03/
+
+# mcap format bag
+ros2 bag merge -o rosbag2_merged/ rosbag2_2021_08_20-12_28_24/ rosbag2_2021_08_20-12_30_03/ -s mcap
 ```
 
 ### ros2 bag filter
@@ -54,7 +65,12 @@ Usage:
 If you want to include the specified topic, use `-i` or `--include`.
 
 ```sh
+# sqlite3 format bag
 ros2 bag filter -o rosbag2_filtered/ rosbag2_merged/ -i "/system/emergency/turn_signal_cmd" "/autoware/driving_capability"
+
+# mcap format bag
+ros2 bag filter -o rosbag2_filtered/ rosbag2_merged/ -i "/system/emergency/turn_signal_cmd" "/autoware/driving_capability" -s mcap
+
 # use regular expression
 ros2 bag filter -o rosbag2_filtered/ rosbag2_merged/ -i "/sensing/.*" "/vehicle/.*"
 ```
@@ -62,6 +78,7 @@ ros2 bag filter -o rosbag2_filtered/ rosbag2_merged/ -i "/sensing/.*" "/vehicle/
 If you want to exclude the specified topic, use `-x` or `--exclude`.
 
 ```sh
+# sqlite3 format bag
 ros2 bag filter -o rosbag2_filtered/ rosbag2_merged/ -x "/system/emergency/turn_signal_cmd" "/autoware/driving_capability"
 # use regular expression
 ros2 bag filter -o rosbag2_filtered/ rosbag2_merged/ -x "/sensing/.*" "/vehicle/.*"
@@ -78,14 +95,17 @@ Save the specified range of data as a bag file by specifying the start time and 
 Usage:
 
 ```sh
-# from 1629430104.911167670 to the bag end time
-ros2 bag slice input_bag -o sliced_from -s 1629430104.911167670
+# sqlite3 format, from 1629430104.911167670 to the bag end time
+ros2 bag slice input_bag -o sliced_from -b 1629430104.911167670
 
-# from the bag start time to 1629430124
+# mcap format, from 1629430104.911167670 to the bag end time
+ros2 bag slice input_bag -o sliced_from -b 1629430104.911167670 -s mcap
+
+# from the bag begging time to 1629430124
 ros2 bag slice input_bag -o sliced_till -e 1629430124
 
 # from 1629430104.911 to 1629430124
-ros2 bag slice input_bag -o sliced_between -s 1629430104.911 -e 1629430124
+ros2 bag slice input_bag -o sliced_between -b 1629430104.911 -e 1629430124
 ```
 
 #### split into multiple files

--- a/ros2bag_extensions/ros2bag_extensions/verb/__init__.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/__init__.py
@@ -17,7 +17,7 @@ from rosbag2_py import *
 
 
 def create_reader(bag_dir: str, storage_type: str) -> SequentialReader:
-    storage_options = get_default_storage_options(bag_dir, storage_type)
+    storage_options = get_storage_options(bag_dir, storage_type)
     converter_options = get_default_converter_options()
 
     reader = SequentialReader()
@@ -32,7 +32,7 @@ def get_default_converter_options() -> ConverterOptions:
     )
 
 
-def get_default_storage_options(uri: str, storage_type: str) -> StorageOptions:
+def get_storage_options(uri: str, storage_type: str) -> StorageOptions:
     return StorageOptions(
         uri=uri,
         storage_id=storage_type,

--- a/ros2bag_extensions/ros2bag_extensions/verb/__init__.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/__init__.py
@@ -16,8 +16,8 @@ from datetime import datetime
 from rosbag2_py import *
 
 
-def create_reader(bag_dir: str) -> SequentialReader:
-    storage_options = get_default_storage_options(bag_dir)
+def create_reader(bag_dir: str, storage_type: str) -> SequentialReader:
+    storage_options = get_default_storage_options(bag_dir, storage_type)
     converter_options = get_default_converter_options()
 
     reader = SequentialReader()
@@ -32,13 +32,13 @@ def get_default_converter_options() -> ConverterOptions:
     )
 
 
-def get_default_storage_options(uri: str) -> StorageOptions:
+def get_default_storage_options(uri: str, storage_type: str) -> StorageOptions:
     return StorageOptions(
         uri=uri,
-        storage_id="sqlite3",
+        storage_id=storage_type,
     )
 
 
-def get_starting_time(uri: str) -> datetime:
-    info = Info().read_metadata(uri, "sqlite3")
+def get_starting_time(uri: str, storage_type: str) -> datetime:
+    info = Info().read_metadata(uri, storage_type)
     return info.starting_time

--- a/ros2bag_extensions/ros2bag_extensions/verb/filter.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/filter.py
@@ -20,7 +20,7 @@ from ros2bag.api import check_path_exists
 from ros2bag.verb import VerbExtension
 from rosbag2_py import *
 
-from . import create_reader, get_default_converter_options, get_default_storage_options
+from . import create_reader, get_default_converter_options, get_storage_options
 
 
 class FilterVerb(VerbExtension):
@@ -48,7 +48,7 @@ class FilterVerb(VerbExtension):
         reader.set_filter(topic_filter)
 
         # Open writer
-        storage_options = get_default_storage_options(output_bag_dir, storage_type)
+        storage_options = get_storage_options(output_bag_dir, storage_type)
         converter_options = get_default_converter_options()
         writer = SequentialWriter()
         writer.open(storage_options, converter_options)

--- a/ros2bag_extensions/ros2bag_extensions/verb/filter.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/filter.py
@@ -76,7 +76,7 @@ class FilterVerb(VerbExtension):
         group.add_argument("-i", "--include", nargs="+", help="Topics to include.")
         group.add_argument("-x", "--exclude", nargs="+", help="Topics to exclude.")
         parser.add_argument(
-            "-s", "--storage", default="sqlite3", help="storage identifier to be used, defaults to 'sqlite3'")
+            "-s", "--storage", required=False, default="sqlite3", help="storage identifier to be used, defaults to 'sqlite3'")
 
 
     def main(self, *, args):

--- a/ros2bag_extensions/ros2bag_extensions/verb/filter.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/filter.py
@@ -25,8 +25,8 @@ from . import create_reader, get_default_converter_options, get_default_storage_
 
 class FilterVerb(VerbExtension):
     ''' Filter by topic names '''
-    def _bag2filter(self, input_bag_dir: str, output_bag_dir: str, include_topics: List[str], exclude_topics: List[str]) -> None:
-        reader = create_reader(input_bag_dir)
+    def _bag2filter(self, input_bag_dir: str, output_bag_dir: str, include_topics: List[str], exclude_topics: List[str], storage_type: str) -> None:
+        reader = create_reader(input_bag_dir, storage_type)
 
         # Filter topics
         if include_topics:
@@ -48,7 +48,7 @@ class FilterVerb(VerbExtension):
         reader.set_filter(topic_filter)
 
         # Open writer
-        storage_options = get_default_storage_options(output_bag_dir)
+        storage_options = get_default_storage_options(output_bag_dir, storage_type)
         converter_options = get_default_converter_options()
         writer = SequentialWriter()
         writer.open(storage_options, converter_options)
@@ -75,10 +75,12 @@ class FilterVerb(VerbExtension):
         group = parser.add_mutually_exclusive_group(required=True)
         group.add_argument("-i", "--include", nargs="+", help="Topics to include.")
         group.add_argument("-x", "--exclude", nargs="+", help="Topics to exclude.")
+        parser.add_argument(
+            "-s", "--storage", default="sqlite3", help="storage identifier to be used, defaults to 'sqlite3'")
 
 
     def main(self, *, args):
         if os.path.isdir(args.output):
             raise FileExistsError("Output folder '{}' already exists.".format(args.output))
 
-        self._bag2filter(args.bag_directory, args.output, args.include, args.exclude)
+        self._bag2filter(args.bag_directory, args.output, args.include, args.exclude, args.storage)

--- a/ros2bag_extensions/ros2bag_extensions/verb/merge.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/merge.py
@@ -20,14 +20,14 @@ from ros2bag.verb import VerbExtension
 from rosbag2_py import *
 
 from . import (create_reader, get_default_converter_options,
-               get_default_storage_options, get_starting_time)
+               get_storage_options, get_starting_time)
 
 
 class MergeVerb(VerbExtension):
     ''' Combine multiple bag files '''
     def _bag2merge(self, input_bags: List[str], output_bag_dir: str, storage_type: str) -> None:
         # Open writer
-        storage_options = get_default_storage_options(output_bag_dir, storage_type)
+        storage_options = get_storage_options(output_bag_dir, storage_type)
         converter_options = get_default_converter_options()
         writer = SequentialWriter()
         writer.open(storage_options, converter_options)

--- a/ros2bag_extensions/ros2bag_extensions/verb/merge.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/merge.py
@@ -25,18 +25,18 @@ from . import (create_reader, get_default_converter_options,
 
 class MergeVerb(VerbExtension):
     ''' Combine multiple bag files '''
-    def _bag2merge(self, input_bags: List[str], output_bag_dir: str) -> None:
+    def _bag2merge(self, input_bags: List[str], output_bag_dir: str, storage_type: str) -> None:
         # Open writer
-        storage_options = get_default_storage_options(output_bag_dir)
+        storage_options = get_default_storage_options(output_bag_dir, storage_type)
         converter_options = get_default_converter_options()
         writer = SequentialWriter()
         writer.open(storage_options, converter_options)
 
         # NOTE: To make SequentialWriter work properly, read starting_time in order of oldest to newest.
-        input_bags = sorted(input_bags, key=get_starting_time)
+        input_bags = sorted(input_bags, key=lambda bag: get_starting_time(bag, storage_type))
 
         for input_bag in input_bags:
-            reader = create_reader(input_bag)
+            reader = create_reader(input_bag, storage_type)
 
             # Merge
             # NOTE: In the case of SQLite3 storage, it is sorted by ORDERED BY timestamp when reading, so sorting is not necessary when writing.
@@ -55,10 +55,12 @@ class MergeVerb(VerbExtension):
             "bag_directory", type=check_path_exists, nargs="+", help="Bag to filter")
         parser.add_argument(
             "-o", "--output", required=True, help="Output directory")
+        parser.add_argument(
+            "-s", "--storage", required=False, default="sqlite3", help="storage identifier to be used, defaults to 'sqlite3'")
 
 
     def main(self, *, args):
         if os.path.isdir(args.output):
             raise FileExistsError("Output folder '{}' already exists.".format(args.output))
 
-        self._bag2merge(args.bag_directory, args.output)
+        self._bag2merge(args.bag_directory, args.output, args.storage)

--- a/ros2bag_extensions/ros2bag_extensions/verb/slice.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/slice.py
@@ -25,7 +25,7 @@ from . import create_reader, get_default_converter_options, get_default_storage_
 
 class SliceVerb(VerbExtension):
     ''' Save the specified range of data as a bag file by specifying the start time and end time. '''
-    def _bag2slice_with_start_end_time(self, input_bag_dir: str, output_bag_dir: str, start_time: datetime.datetime, end_time: datetime.datetime, latched_topic: list[str]) -> None:
+    def _bag2slice_with_start_end_time(self, input_bag_dir: str, output_bag_dir: str, start_time: datetime.datetime, end_time: datetime.datetime, latched_topic: list[str], storage_type: str) -> None:
         # Check timestamp
         metadata = Info().read_metadata(input_bag_dir, "sqlite3")
 
@@ -38,13 +38,13 @@ class SliceVerb(VerbExtension):
             end_time = metadata.starting_time + metadata.duration
 
         # Open writer
-        storage_options = get_default_storage_options(output_bag_dir)
+        storage_options = get_default_storage_options(output_bag_dir, storage_type)
         converter_options = get_default_converter_options()
         writer = SequentialWriter()
         writer.open(storage_options, converter_options)
 
         # Create topics
-        reader = create_reader(input_bag_dir)
+        reader = create_reader(input_bag_dir, storage_type)
         for topic_type in reader.get_all_topics_and_types():
             writer.create_topic(topic_type)
 
@@ -64,15 +64,15 @@ class SliceVerb(VerbExtension):
                 kept_topics.append((topic_name, msg))
 
     ''' Split and save bag files by specifying the duration. '''
-    def _bag2slice_with_duration(self, input_bag_dir: str, output_bag_dir: str, duration: float) -> None:
+    def _bag2slice_with_duration(self, input_bag_dir: str, output_bag_dir: str, duration: float, storage_type: str) -> None:
         # Open writer
-        storage_options = get_default_storage_options(output_bag_dir)
+        storage_options = get_default_storage_options(output_bag_dir, storage_type)
         converter_options = get_default_converter_options()
         writer = SequentialWriterWrapper()
         writer.open(storage_options, converter_options)
 
         # Create topics
-        reader = create_reader(input_bag_dir)
+        reader = create_reader(input_bag_dir, storage_type)
         for topic_type in reader.get_all_topics_and_types():
             writer.create_topic(topic_type)
 
@@ -100,8 +100,9 @@ class SliceVerb(VerbExtension):
         parser.add_argument(
             "-d", "--duration", type=float, help="duration second for slice")
         parser.add_argument(
-            "-l", "--latched-topics", nargs="*", type=str, help="list of latched topics", default=[]
-        )
+            "-l", "--latched-topics", nargs="*", type=str, help="list of latched topics", default=[])
+        parser.add_argument(
+            "-s", "--storage", default="sqlite3", help="storage identifier to be used, defaults to 'sqlite3'")
 
     def main(self, *, args):
         if os.path.isdir(args.output):
@@ -109,8 +110,8 @@ class SliceVerb(VerbExtension):
 
         # duration mode
         if args.duration is not None:
-            self._bag2slice_with_duration(args.bag_directory, args.output, args.duration)
+            self._bag2slice_with_duration(args.bag_directory, args.output, args.duration, args.storage)
         else:  # start and end mode
             dt_start_time = datetime.datetime.fromtimestamp(args.start_time)
             dt_end_time = datetime.datetime.fromtimestamp(args.end_time)
-            self._bag2slice_with_start_end_time(args.bag_directory, args.output, dt_start_time, dt_end_time, args.latched_topics)
+            self._bag2slice_with_start_end_time(args.bag_directory, args.output, dt_start_time, dt_end_time, args.latched_topics, args.storage)

--- a/ros2bag_extensions/ros2bag_extensions/verb/slice.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/slice.py
@@ -20,7 +20,7 @@ from ros2bag.verb import VerbExtension
 from rosbag2_py import *
 from rosbag2_py_wrapper import SequentialWriterWrapper
 
-from . import create_reader, get_default_converter_options, get_default_storage_options
+from . import create_reader, get_default_converter_options, get_storage_options
 
 
 class SliceVerb(VerbExtension):
@@ -38,7 +38,7 @@ class SliceVerb(VerbExtension):
             end_time = metadata.starting_time + metadata.duration
 
         # Open writer
-        storage_options = get_default_storage_options(output_bag_dir, storage_type)
+        storage_options = get_storage_options(output_bag_dir, storage_type)
         converter_options = get_default_converter_options()
         writer = SequentialWriter()
         writer.open(storage_options, converter_options)
@@ -66,7 +66,7 @@ class SliceVerb(VerbExtension):
     ''' Split and save bag files by specifying the duration. '''
     def _bag2slice_with_duration(self, input_bag_dir: str, output_bag_dir: str, duration: float, storage_type: str) -> None:
         # Open writer
-        storage_options = get_default_storage_options(output_bag_dir, storage_type)
+        storage_options = get_storage_options(output_bag_dir, storage_type)
         converter_options = get_default_converter_options()
         writer = SequentialWriterWrapper()
         writer.open(storage_options, converter_options)

--- a/ros2bag_extensions/ros2bag_extensions/verb/slice.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/slice.py
@@ -94,7 +94,7 @@ class SliceVerb(VerbExtension):
         parser.add_argument(
             "-o", "--output", required=True, help="Output directory")
         parser.add_argument(
-            "-s", "--start-time", default=0.0, type=float, help="Start time in nanoseconds")
+            "-b", "--beginning-time", default=0.0, type=float, help="Beginning time in nanoseconds")
         parser.add_argument(
             "-e", "--end-time", default=4102412400, type=float, help="End time in nanoseconds")  # 2100/01/01 00:00:00
         parser.add_argument(
@@ -112,6 +112,6 @@ class SliceVerb(VerbExtension):
         if args.duration is not None:
             self._bag2slice_with_duration(args.bag_directory, args.output, args.duration, args.storage)
         else:  # start and end mode
-            dt_start_time = datetime.datetime.fromtimestamp(args.start_time)
+            dt_start_time = datetime.datetime.fromtimestamp(args.beginning_time)
             dt_end_time = datetime.datetime.fromtimestamp(args.end_time)
             self._bag2slice_with_start_end_time(args.bag_directory, args.output, dt_start_time, dt_end_time, args.latched_topics, args.storage)

--- a/ros2bag_extensions/ros2bag_extensions/verb/slice.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/slice.py
@@ -102,7 +102,7 @@ class SliceVerb(VerbExtension):
         parser.add_argument(
             "-l", "--latched-topics", nargs="*", type=str, help="list of latched topics", default=[])
         parser.add_argument(
-            "-s", "--storage", default="sqlite3", help="storage identifier to be used, defaults to 'sqlite3'")
+            "-s", "--storage", required=False, default="sqlite3", help="storage identifier to be used, defaults to 'sqlite3'")
 
     def main(self, *, args):
         if os.path.isdir(args.output):


### PR DESCRIPTION

## Summary
This pull request introduces support for the MCAP storage format in the ros2bag_extensions package. Previously, the default storage format was SQLite3, and this update allows users to specify the storage format when working with ROS2 bag files.

## Changes
#### Updated Function Signatures:

Modified functions such as create_reader, get_default_storage_options, and get_starting_time to include an additional storage_type parameter.
#### FilterVerb:

Added storage_type parameter to _bag2filter method.
Updated command line arguments to accept storage type with a default value of sqlite3.
#### MergeVerb:

Added storage_type parameter to _bag2merge method.
Updated command line arguments to accept storage type with a default value of sqlite3.
#### SliceVerb:

Added storage_type parameter to _bag2slice_with_start_end_time and _bag2slice_with_duration methods.
Updated command line arguments to accept storage type with a default value of sqlite3.