### PR TITLE
fix: #28 ros2bag info type change

### DIFF
--- a/ros2bag_extensions/ros2bag_extensions/verb/__init__.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/__init__.py
@@ -42,11 +42,17 @@ def get_storage_options(uri: str, storage_type: str) -> StorageOptions:
 
 def get_starting_time(uri: str, storage_type: str) -> datetime:
     info = Info().read_metadata(uri, storage_type)
-    return rcl_py_time_to_datetime(info.starting_time)
+    starting_time: datetime | Time = info.starting_time
+    if isinstance(starting_time, datetime):
+        return starting_time
+    return rcl_py_time_to_datetime(starting_time)
 
 def get_ending_time(uri: str, storage_type: str) -> datetime:
     info = Info().read_metadata(uri, storage_type)
-    return rcl_py_time_to_datetime(info.starting_time + info.duration)
+    ending_time: datetime | Time = info.starting_time + info.duration
+    if isinstance(ending_time, datetime):
+        return ending_time
+    return rcl_py_time_to_datetime(ending_time)
 
 
 def rcl_py_time_to_datetime(ros_time: Time) -> datetime:

--- a/ros2bag_extensions/ros2bag_extensions/verb/__init__.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/__init__.py
@@ -14,6 +14,7 @@
 
 from datetime import datetime
 from rosbag2_py import *
+from rclpy.time import Time
 
 
 def create_reader(bag_dir: str, storage_type: str) -> SequentialReader:
@@ -41,4 +42,14 @@ def get_storage_options(uri: str, storage_type: str) -> StorageOptions:
 
 def get_starting_time(uri: str, storage_type: str) -> datetime:
     info = Info().read_metadata(uri, storage_type)
-    return info.starting_time
+    return rcl_py_time_to_datetime(info.starting_time)
+
+def get_ending_time(uri: str, storage_type: str) -> datetime:
+    info = Info().read_metadata(uri, storage_type)
+    return rcl_py_time_to_datetime(info.starting_time + info.duration)
+
+
+def rcl_py_time_to_datetime(ros_time: Time) -> datetime:
+    second, nanosecond = ros_time.seconds_nanoseconds()
+    timestamp = second + (nanosecond / 10**9)
+    return datetime.fromtimestamp(timestamp)

--- a/ros2bag_extensions/ros2bag_extensions/verb/slice.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/slice.py
@@ -20,22 +20,23 @@ from ros2bag.verb import VerbExtension
 from rosbag2_py import *
 from rosbag2_py_wrapper import SequentialWriterWrapper
 
-from . import create_reader, get_default_converter_options, get_storage_options
+from . import create_reader, get_default_converter_options, get_storage_options, get_starting_time, get_ending_time
 
 
 class SliceVerb(VerbExtension):
     ''' Save the specified range of data as a bag file by specifying the start time and end time. '''
     def _bag2slice_with_start_end_time(self, input_bag_dir: str, output_bag_dir: str, start_time: datetime.datetime, end_time: datetime.datetime, latched_topic: list[str], storage_type: str) -> None:
         # Check timestamp
-        metadata = Info().read_metadata(input_bag_dir, "sqlite3")
+        info_starting_time = get_starting_time(input_bag_dir, storage_type)
+        info_ending_time = get_ending_time(input_bag_dir, storage_type)
 
-        if start_time < metadata.starting_time:
+        if start_time < info_starting_time:
             print("No valid start time set. Start time automatically set the bag start time.")
-            start_time = metadata.starting_time
+            start_time = info_starting_time
 
-        if end_time > metadata.starting_time + metadata.duration:
+        if end_time > info_ending_time:
             print("No valid end time set. End time automatically set the bag end time.")
-            end_time = metadata.starting_time + metadata.duration
+            end_time = info_ending_time
 
         # Open writer
         storage_options = get_storage_options(output_bag_dir, storage_type)

--- a/ros2bag_extensions/test/test_verb.py
+++ b/ros2bag_extensions/test/test_verb.py
@@ -1,0 +1,8 @@
+from ros2bag_extensions.verb import rcl_py_time_to_datetime
+from rclpy.time import Time
+from datetime import datetime
+
+def test_rcl_py_time_to_datetime() -> None:
+    ros_time = Time(seconds=1234567890, nanoseconds=987654321)
+    datetime_time = rcl_py_time_to_datetime(ros_time)
+    assert datetime_time == datetime.fromtimestamp(1234567890.987654321)


### PR DESCRIPTION
closes: #28

Why is this change necessary?
Because the type returned by metadata.starting_time has changed.

datetime.datetime -> rclpy.time.Time

Please confirm your rosbag2_py version

```shell
ros-humble-rosbag2-py/jammy,now 0.15.12-1jammy.20240730.152125
```