### PR TITLE
docs: update snipet Galactic to Humble

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cd $HOME/extension_ws/src
 git clone git@github.com:tier4/ros2bag_extensions.git
 # build workspace
 cd $HOME/extension_ws
-source /opt/ros/galactic/setup.bash
+source /opt/ros/humble/setup.bash
 rosdep install --from-paths . --ignore-src --rosdistro=${ROS_DISTRO}
 colcon build --symlink-install --catkin-skip-building-tests --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=Release
 ```


### PR DESCRIPTION
From commit 824055926cc0f8d4e94ddf7b1710af89dd82d9b7, it appears that the supported ROS2 distribution for this extension has changed from Galactic to Humble. I will update the instructions in the code block accordingly.

