### PR TITLE
fix: delete exclude topic metadata

### DIFF
--- a/ros2bag_extensions/ros2bag_extensions/verb/filter.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/filter.py
@@ -53,9 +53,13 @@ class FilterVerb(VerbExtension):
         writer = SequentialWriter()
         writer.open(storage_options, converter_options)
 
+        # get all topics metadata
+        input_bag_all_topics_meta = reader.get_all_topics_and_types()
+        candidate_topic_metadata = [ tm for tm in input_bag_all_topics_meta if tm.name in topic_list]
+
         # Create topics
-        for topic_type in reader.get_all_topics_and_types():
-            writer.create_topic(topic_type)
+        for tm in candidate_topic_metadata:
+            writer.create_topic(tm)
 
         # Write
         while reader.has_next():


### PR DESCRIPTION
## Descriptions
filterしても `ros2 bag info`するとfilterしたはずのトピックがCount: 0で残ってしまう問題を修正

## Tests Perfomed
以下filter前のrosbagで `/api/iv_msgs/vehicle/status/control_mode` を消し去りたいとすると
```
$ ros2 bag filter . -o filtered -i "/sensing/.*" "/vehicle/.*"

# filter前
$ ros2 bag info .

Files:             test_0.db3
Bag size:          33.5 MiB
Storage id:        
Duration:          78.603200419s
Start:             May 28 2025 15:10:14.406519716 (1748412614.406519716)
End:               May 28 2025 15:11:33.009720135 (1748412693.009720135)
Messages:          245742
Topic information: Topic: /api/iv_msgs/vehicle/status/control_mode | Type: autoware_auto_vehicle_msgs/msg/ControlModeReport | Count: 1560 | Serialization Format: cdr
                   Topic: /sensing/imu/imu_data | Type: sensor_msgs/msg/Imu | Count: 15625 | Serialization Format: cdr
                   Topic: /sensing/imu/tamagawa/from_can_bus | Type: can_msgs/msg/Frame | Count: 93814 | Serialization Format: cdr
                   Topic: /sensing/imu/tamagawa/imu_raw | Type: sensor_msgs/msg/Imu | Count: 15639 | Serialization Format: cdr
                   Topic: /sensing/imu/tamagawa/socket_can_receiver/transition_event | Type: lifecycle_msgs/msg/TransitionEvent | Count: 0 | Serialization Format: cdr
                   Topic: /vehicle/status/actuation_status | Type: tier4_vehicle_msgs/msg/ActuationStatusStamped | Count: 3883 | Serialization Format: cdr
                   Topic: /vehicle/status/battery_charge | Type: tier4_vehicle_msgs/msg/BatteryStatus | Count: 391 | Serialization Format: cdr
                   Topic: /vehicle/status/control_mode | Type: autoware_vehicle_msgs/msg/ControlModeReport | Count: 1568 | Serialization Format: cdr
                   Topic: /vehicle/status/door_status | Type: tier4_api_msgs/msg/DoorStatus | Count: 389 | Serialization Format: cdr
                   Topic: /vehicle/status/gear_status | Type: autoware_vehicle_msgs/msg/GearReport | Count: 3880 | Serialization Format: cdr
                   Topic: /vehicle/status/hazard_lights_status | Type: autoware_vehicle_msgs/msg/HazardLightsReport | Count: 388 | Serialization Format: cdr
                   Topic: /vehicle/status/steering_status | Type: autoware_vehicle_msgs/msg/SteeringReport | Count: 3852 | Serialization Format: cdr
                   Topic: /vehicle/status/steering_wheel_status | Type: tier4_vehicle_msgs/msg/SteeringWheelStatusStamped | Count: 3853 | Serialization Format: cdr
                   Topic: /vehicle/status/turn_indicators_status | Type: autoware_vehicle_msgs/msg/TurnIndicatorsReport | Count: 388 | Serialization Format: cdr
                   Topic: /vehicle/status/velocity_status | Type: autoware_vehicle_msgs/msg/VelocityReport | Count: 3883 | Serialization Format: cdr


# filter後
$ ros2 bag info filtered/

Files:             filtered_0.db3
Bag size:          27.1 MiB
Storage id:        sqlite3
Duration:          78.603200419s
Start:             May 28 2025 15:10:14.406519716 (1748412614.406519716)
End:               May 28 2025 15:11:33.009720135 (1748412693.009720135)
Messages:          244182
Topic information: Topic: /sensing/imu/imu_data | Type: sensor_msgs/msg/Imu | Count: 15625 | Serialization Format: cdr
                   Topic: /sensing/imu/tamagawa/from_can_bus | Type: can_msgs/msg/Frame | Count: 93814 | Serialization Format: cdr
                   Topic: /sensing/imu/tamagawa/imu_raw | Type: sensor_msgs/msg/Imu | Count: 15639 | Serialization Format: cdr
                   Topic: /sensing/imu/tamagawa/socket_can_receiver/transition_event | Type: lifecycle_msgs/msg/TransitionEvent | Count: 0 | Serialization Format: cdr
                   Topic: /vehicle/status/actuation_status | Type: tier4_vehicle_msgs/msg/ActuationStatusStamped | Count: 3883 | Serialization Format: cdr
                   Topic: /vehicle/status/battery_charge | Type: tier4_vehicle_msgs/msg/BatteryStatus | Count: 391 | Serialization Format: cdr
                   Topic: /vehicle/status/control_mode | Type: autoware_vehicle_msgs/msg/ControlModeReport | Count: 1568 | Serialization Format: cdr
                   Topic: /vehicle/status/door_status | Type: tier4_api_msgs/msg/DoorStatus | Count: 389 | Serialization Format: cdr
                   Topic: /vehicle/status/gear_status | Type: autoware_vehicle_msgs/msg/GearReport | Count: 3880 | Serialization Format: cdr
                   Topic: /vehicle/status/hazard_lights_status | Type: autoware_vehicle_msgs/msg/HazardLightsReport | Count: 388 | Serialization Format: cdr
                   Topic: /vehicle/status/steering_status | Type: autoware_vehicle_msgs/msg/SteeringReport | Count: 3852 | Serialization Format: cdr
                   Topic: /vehicle/status/steering_wheel_status | Type: tier4_vehicle_msgs/msg/SteeringWheelStatusStamped | Count: 3853 | Serialization Format: cdr
                   Topic: /vehicle/status/turn_indicators_status | Type: autoware_vehicle_msgs/msg/TurnIndicatorsReport | Count: 388 | Serialization Format: cdr
                   Topic: /vehicle/status/velocity_status | Type: autoware_vehicle_msgs/msg/VelocityReport | Count: 3883 | Serialization Format: cdr

```