### PR TITLE
chore: update argument help text for slice

### DIFF
--- a/ros2bag_extensions/ros2bag_extensions/verb/slice.py
+++ b/ros2bag_extensions/ros2bag_extensions/verb/slice.py
@@ -95,9 +95,9 @@ class SliceVerb(VerbExtension):
         parser.add_argument(
             "-o", "--output", required=True, help="Output directory")
         parser.add_argument(
-            "-b", "--beginning-time", default=0.0, type=float, help="Beginning time in nanoseconds")
+            "-b", "--beginning-time", default=0.0, type=float, help="Beginning time in Unix timestamp (seconds)")  # 1970/01/01 00:00:00
         parser.add_argument(
-            "-e", "--end-time", default=4102412400, type=float, help="End time in nanoseconds")  # 2100/01/01 00:00:00
+            "-e", "--end-time", default=4102412400, type=float, help="End time in Unix timestamp (seconds)")  # 2100/01/01 00:00:00
         parser.add_argument(
             "-d", "--duration", type=float, help="duration second for slice")
         parser.add_argument(


### PR DESCRIPTION
## Background
Help text for `slice` arguments were like following.
```
~$ ros2 bag slice -h
               :
  -b BEGINNING_TIME, --beginning-time BEGINNING_TIME
                        Beginning time in nanoseconds
  -e END_TIME, --end-time END_TIME
                        End time in nanoseconds
```
`--beginning-time` and `--end-time` are actually Unix time in second instead of nanosecond.
So I would like to change these description.

## Test Perfomed
I ran ros2 bag slice -h to confirm the updated help text is displayed as expected.
```
~$ ros2 bag slice -h
usage: ros2 bag slice [-h] -o OUTPUT [-b BEGINNING_TIME] [-e END_TIME] [-d DURATION] [-l [LATCHED_TOPICS ...]] [-s STORAGE]
                      bag_directory

Save the specified range of data as a bag file by specifying the start time and end time

positional arguments:
  bag_directory         Bag to filter

options:
  -h, --help            show this help message and exit
  -o OUTPUT, --output OUTPUT
                        Output directory
  -b BEGINNING_TIME, --beginning-time BEGINNING_TIME
                        Beginning time in Unix timestamp (seconds)
  -e END_TIME, --end-time END_TIME
                        End time in Unix timestamp (seconds)
  -d DURATION, --duration DURATION
                        duration second for slice
  -l [LATCHED_TOPICS ...], --latched-topics [LATCHED_TOPICS ...]
                        list of latched topics
  -s STORAGE, --storage STORAGE
                        storage identifier to be used, defaults to 'sqlite3'
```
